### PR TITLE
Add check for lang attribute in <html>

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ A list of every a11y concern Checka11y.css will look for and highlight:
 - Missing `alt` attributes on images
 - Missing `title` on `<iframe>`
 - Checks `<li>` is the **only** child of `<ol>` and `<ul>`
+- Missing `lang` on `<html>`
 
 Other features:
 

--- a/checka11y.css
+++ b/checka11y.css
@@ -19,7 +19,7 @@ html:not([lang]) body{
 }
 
 html:not([lang]) body::after{
-  content: "ERROR: html has no lang attribute. " !important;
+  content: 'ERROR: html has no lang attribute.' !important;
   font-family: var(--checka11y-font, cursive);
 }
 

--- a/checka11y.css
+++ b/checka11y.css
@@ -11,6 +11,19 @@
 }
 
 /**
+* HTML
+*/
+
+html:not([lang]) body{
+  border: var(--checka11y-error-border-width, 5px) solid var(--checka11y-error-color, red) !important;
+}
+
+html:not([lang]) body::after{
+  content: "ERROR: html has no lang attribute. " !important;
+  font-family: var(--checka11y-font, cursive);
+}
+
+/**
  * Images
  */
 

--- a/test/index.html
+++ b/test/index.html
@@ -31,5 +31,8 @@
         <div>Hello, I'm a div inside a &lt;ul&gt;</div>
       </ol>
     </section>
+    <section>
+      <h2>HTML: html tag should have a lang attribute</h2>
+    </section>
   </body>
 </html>


### PR DESCRIPTION
The `<html>` tag should have a `lang` attribute to tell the screen reader what language the page is in. 

Evidence: https://www.w3.org/WAI/standards-guidelines/act/rules/html-page-lang-b5c3f8/