### PR TITLE
Check for a tab index of -1 on commonly tabbed to elements(#8) : a11y feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,15 @@ A list of every a11y concern Checka11y.css will check for and highlight:
   - `<textarea>`
   - `<video controls>`
 - Checks the `dir` attribute is only set to `ltr`, `rtl` or `auto`
+- Checks for a tab index value of -1 on the following elements:
+  - `<a>[href]`
+  - `<area>[href]`
+  - `<input> that is not disabled`
+  - `<select> that is not disabled`
+  - `<textarea> that is not disabled`
+  - `<button> that is not disabled`
+  - `<iframe>`
+  - `Any HTML element with editable content`
 
 Other features:
 

--- a/checka11y.css
+++ b/checka11y.css
@@ -242,3 +242,57 @@ a video[controls]::after {
   content: "ERROR: The dir attribute can only have the values, ltr, rtl and auto." !important;
   font-family: var(--checka11y-font, cursive);
 }
+
+/*Ensure that the tab index of commonly tabbed to elements is not -1*/
+
+a[href][tabindex="-1"],
+area[href][tabindex="-1"],
+input:not([disabled])[tabindex="-1"],
+select:not([disabled])[tabindex="-1"],
+textarea:not([disabled])[tabindex="-1"],
+button:not([disabled])[tabindex="-1"],
+iframe[tabindex="-1"],
+[contentEditable="true"][tabindex="-1"] {
+  border: var(--checka11y-error-border-width, 5px) solid
+    var(--checka11y-error-color, red) !important;
+}
+
+a[href][tabindex="-1"]::after {
+  content: "ERROR : Ensure that <a> with an href attribute doesn't have a tab index of -1" !important;
+  font-family: var(--checka11y-font, cursive);
+}
+
+area[href][tabindex="-1"]::after {
+  content: "ERROR : Ensure that <area> with an href attribute doesn't have a tab index of -1" !important;
+  font-family: var(--checka11y-font, cursive);
+}
+
+input:not([disabled])[tabindex="-1"]::after {
+  content: "ERROR : Ensure that <input> that is not disabled doesn't have a tab index of -1" !important;
+  font-family: var(--checka11y-font, cursive);
+}
+
+select:not([disabled])[tabindex="-1"]::after {
+  content: "ERROR : Ensure that <select> that is not disabled doesn't have a tab index of -1" !important;
+  font-family: var(--checka11y-font, cursive);
+}
+
+textarea:not([disabled])[tabindex="-1"]::after {
+  content: "ERROR : Ensure that <textarea> that is not disabled doesn't have a tab index of -1" !important;
+  font-family: var(--checka11y-font, cursive);
+}
+
+button:not([disabled])[tabindex="-1"]::after {
+  content: "ERROR : Ensure that <button> that is not disabled doesn't have a tab index of -1" !important;
+  font-family: var(--checka11y-font, cursive);
+}
+
+iframe[tabindex="-1"]::after {
+  content: "ERROR : Ensure that <iframe> doesn't have a tab index of -1" !important;
+  font-family: var(--checka11y-font, cursive);
+}
+
+[contentEditable="true"][tabindex="-1"]::after {
+  content: "ERROR : Ensure that HTML elements with editable content don't have a tab index of -1" !important;
+  font-family: var(--checka11y-font, cursive);
+}

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "Veeresh (https://github.com/veerreshr)",
     "Devin Ford (https://github.com/devindford)",
     "Shaurya Vardhan <gsshaurya@gmail.com> (https://github.com/wulforr)",
-    "Emma Dawson (https://github.com/emmalearnscode)"
+    "Emma Dawson (https://github.com/emmalearnscode)",
+    "Manaswini Munuguri (https://github.com/Manaswini1832)"
   ],
   "keywords": [
     "checka11y",

--- a/test/index.html
+++ b/test/index.html
@@ -116,5 +116,31 @@
       <h2>Dir attribute: The dir attribute can only have the values, ltr, rtl and auto.</h2>
       <p dir="lr">This is an &lt;p&gt; with dir attribute set to lr</p>
     </section>
+    <section>
+      <h2>Check the tab index of commonly tabbed to elements and show an error if it is -1</h2>
+      <h3>Links with an href attribute cannot have a tab index of -1</h3>
+      <a href="https://checka11y.jackdomleo.dev" target="_self" tabindex="-1">I am an anchor tag ( with an href attribute ) having a tab index of-1</a>
+      <h3>&lt;area&gt; elements with an href attribute cannot have a tab index of -1</h3>
+      <img src="./assets/a11y.png" alt="Test for area elements with an href attribute" usemap="#workmap" width="400" height="379"/>
+      <map name="workmap">
+        <area shape="rect" coords="34,44,270,350" alt="Clickable area" href="https://checka11y.jackdomleo.dev" tabindex="-1"/>
+      </map>
+      <h3>&lt;input&gt; elements that are not disabled cannot have a tab index of-1</h3>
+      <label for="test-input"></label>
+      <input type="text" placeholder="I am input tag" name="test-input" id="test-input" tabindex="-1"/>
+      <h3>&lt;select&gt; elements that are not disabled cannot have a tab index of-1</h3>
+      <select name="options" id="options" tabindex="-1">
+        <option value="first-option">First option</option>
+        <option value="second-option">Second option</option>
+      </select>
+      <h3>&lt;textarea&gt; elements that are not disabled cannot have a tab index of -1</h3>
+      <textarea placeholder="Hello, I am a textarea" tabindex="-1"></textarea>
+      <h3>&lt;button&gt; elements that are not disabled cannot have a tab index of-1</h3>
+      <button tabindex="-1">Hello, I am a button</button>
+      <h3>&lt;iframe&gt; elements cannot have a tab index of -1</h3>
+      <iframe src="https://checka11y.jackdomleo.dev" height="500" width="500"></iframe>
+      <h3>HTML elements with editable content cannot have a tab index of -1</h3>
+      <p contenteditable="true" tabindex="-1">I am a paragraph tag with editable content</p>
+    </section>
   </body>
 </html>


### PR DESCRIPTION
## Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description

I have added the feature to check for a tab index of -1 and show an error, on commonly tabbed to elements like

-  Anchor tag with href attribute

-  Area element with href attribute

-  Input that is not disabled

-  Select that is not disabled

-  Textarea that is not disabled

-  Button that is not disabled

-  iframe

- Any HTML element with editable content

Resolves #8 (the first part of the issue)


## Link(s)

[An article on accessibility for keyboard users](https://webaim.org/techniques/keyboard/tabindex)


## Screenshot(s)

![Result of the feature that checks for a tab index of -1](https://user-images.githubusercontent.com/58681405/94898788-c40e6e00-04af-11eb-90b3-e832186bc44f.png)


## Checklist:

- [x] I have thoroughly read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines.
- [x] I understand my pull request will be thoroughly reviewed at high detail.
- [x] I understand the work in my pull request will **only** be available in the next version release of Checka11y.css and not in the current version release.
- [x] I confirm the work in this pull request is valid according to my findings and is not something for anything personal.
- [x] I have updated the [README](../README.md) where and if applicable (still put an `x` if you have considered this but thought there was nothing to add or modify).
- [x] I have added myself to the `contributors` section in `package.json` (still put an `x` if you have considered this but decided not to add yourself).
- [x] I have checked I have **not** committed any **accidental** files.
- [ ] I have tested all the main modern browsers (I.e. Chrome, Firefox, Edge, Safari - please leave this unchecked if there were any browsers listed you could not test and list them in the [help](#help) section with details why you couldn't test that browser)
- [x] All new and existing a11y checks still work correctly (compare your local `test/index.html` to the `test/index.html` in the `master` branch).

## Help

I could not test in Safari because I do not have access to an Apple device. 
