### PR TITLE
Check buttons/links have meaningful content

### DIFF
--- a/checka11y.css
+++ b/checka11y.css
@@ -55,7 +55,7 @@ button label::after {
 }
 
 button:not([aria-label]):not([aria-labelledby]):empty::after {
-  content: "ERROR: Ensure that <button> has meaningful content or is labeled appropriately." !important;
+  content: "ERROR: Ensure that <button> has meaningful content or is labelled appropriately." !important;
 }
 
 [dir]:not([dir="rtl"]):not([dir="ltr"]):not([dir="auto"])::after {
@@ -99,7 +99,7 @@ a label::after {
 }
 
 a[href]:not([aria-label]):not([aria-labelledby]):empty::after {
-  content: "ERROR: Ensure that <a> has meaningful content or is labeled appropriately." !important;
+  content: "ERROR: Ensure that <a> has meaningful content or is labelled appropriately." !important;
 }
 
 ol > *:not(li)::after, ul > *:not(li)::after {

--- a/checka11y.css
+++ b/checka11y.css
@@ -18,7 +18,7 @@
           box-shadow: 0 0 0 0.25rem var(--border-error);
 }
 
-button button::after, button details::after, button label::after, [dir]:not([dir="rtl"]):not([dir="ltr"]):not([dir="auto"])::after, h1:empty::after, h2:empty::after, h3:empty::after, h4:empty::after, h5:empty::after, h6:empty::after, h1 [aria-hidden]::after, h2 [aria-hidden]::after, h3 [aria-hidden]::after, h4 [aria-hidden]::after, h5 [aria-hidden]::after, h6 [aria-hidden]::after, html:not([lang]) body::before, html[lang=""] body::before, a button::after, a details::after, a label::after, ol > *:not(li)::after, ul > *:not(li)::after, dl > *:not(dt):not(dd)::after, nav:not([aria-label]):not([aria-labelledby]) ~ nav::after, nav ~ nav:not([aria-label]):not([aria-labelledby])::after, a[href][tabindex="-1"]::after, area[href][tabindex="-1"]::after, input:not([disabled])[tabindex="-1"]::after, select:not([disabled])[tabindex="-1"]::after, textarea:not([disabled])[tabindex="-1"]::after, button:not([disabled])[tabindex="-1"]::after, iframe[tabindex="-1"]::after, [contentEditable="true"][tabindex="-1"]::after, [accesskey]::after, [style*="!important"]::after, a[target="_blank"]::after {
+button button::after, button details::after, button label::after, button:not([aria-label]):not([aria-labelledby]):empty::after, [dir]:not([dir="rtl"]):not([dir="ltr"]):not([dir="auto"])::after, h1:empty::after, h2:empty::after, h3:empty::after, h4:empty::after, h5:empty::after, h6:empty::after, h1 [aria-hidden]::after, h2 [aria-hidden]::after, h3 [aria-hidden]::after, h4 [aria-hidden]::after, h5 [aria-hidden]::after, h6 [aria-hidden]::after, html:not([lang]) body::before, html[lang=""] body::before, a button::after, a details::after, a label::after, a[href]:not([aria-label]):not([aria-labelledby]):empty::after, ol > *:not(li)::after, ul > *:not(li)::after, dl > *:not(dt):not(dd)::after, nav:not([aria-label]):not([aria-labelledby]) ~ nav::after, nav ~ nav:not([aria-label]):not([aria-labelledby])::after, a[href][tabindex="-1"]::after, area[href][tabindex="-1"]::after, input:not([disabled])[tabindex="-1"]::after, select:not([disabled])[tabindex="-1"]::after, textarea:not([disabled])[tabindex="-1"]::after, button:not([disabled])[tabindex="-1"]::after, iframe[tabindex="-1"]::after, [contentEditable="true"][tabindex="-1"]::after, [accesskey]::after, [style*="!important"]::after, a[target="_blank"]::after {
   display: block;
   font-size: 1.2rem;
   font-weight: 700;
@@ -26,7 +26,7 @@ button button::after, button details::after, button label::after, [dir]:not([dir
   border-radius: 0.75rem;
 }
 
-button button::after, button details::after, button label::after, [dir]:not([dir="rtl"]):not([dir="ltr"]):not([dir="auto"])::after, h1:empty::after, h2:empty::after, h3:empty::after, h4:empty::after, h5:empty::after, h6:empty::after, h1 [aria-hidden]::after, h2 [aria-hidden]::after, h3 [aria-hidden]::after, h4 [aria-hidden]::after, h5 [aria-hidden]::after, h6 [aria-hidden]::after, html:not([lang]) body::before, html[lang=""] body::before, a button::after, a details::after, a label::after, ol > *:not(li)::after, ul > *:not(li)::after, dl > *:not(dt):not(dd)::after, nav:not([aria-label]):not([aria-labelledby]) ~ nav::after, nav ~ nav:not([aria-label]):not([aria-labelledby])::after, a[href][tabindex="-1"]::after, area[href][tabindex="-1"]::after, input:not([disabled])[tabindex="-1"]::after, select:not([disabled])[tabindex="-1"]::after, textarea:not([disabled])[tabindex="-1"]::after, button:not([disabled])[tabindex="-1"]::after, iframe[tabindex="-1"]::after, [contentEditable="true"][tabindex="-1"]::after {
+button button::after, button details::after, button label::after, button:not([aria-label]):not([aria-labelledby]):empty::after, [dir]:not([dir="rtl"]):not([dir="ltr"]):not([dir="auto"])::after, h1:empty::after, h2:empty::after, h3:empty::after, h4:empty::after, h5:empty::after, h6:empty::after, h1 [aria-hidden]::after, h2 [aria-hidden]::after, h3 [aria-hidden]::after, h4 [aria-hidden]::after, h5 [aria-hidden]::after, h6 [aria-hidden]::after, html:not([lang]) body::before, html[lang=""] body::before, a button::after, a details::after, a label::after, a[href]:not([aria-label]):not([aria-labelledby]):empty::after, ol > *:not(li)::after, ul > *:not(li)::after, dl > *:not(dt):not(dd)::after, nav:not([aria-label]):not([aria-labelledby]) ~ nav::after, nav ~ nav:not([aria-label]):not([aria-labelledby])::after, a[href][tabindex="-1"]::after, area[href][tabindex="-1"]::after, input:not([disabled])[tabindex="-1"]::after, select:not([disabled])[tabindex="-1"]::after, textarea:not([disabled])[tabindex="-1"]::after, button:not([disabled])[tabindex="-1"]::after, iframe[tabindex="-1"]::after, [contentEditable="true"][tabindex="-1"]::after {
   color: var(--text-error);
   border: 0.4rem solid var(--border-error);
   background-color: var(--bg-error);
@@ -52,6 +52,10 @@ button details::after {
 
 button label::after {
   content: "ERROR: Ensure that <label> is not a child of <button> as it is an invalid HTML." !important;
+}
+
+button:not([aria-label]):not([aria-labelledby]):empty::after {
+  content: "ERROR: Ensure that <button> has meaningful content or is labeled appropriately." !important;
 }
 
 [dir]:not([dir="rtl"]):not([dir="ltr"]):not([dir="auto"])::after {
@@ -92,6 +96,10 @@ a details::after {
 
 a label::after {
   content: "ERROR: Ensure that <label> is not a child of <a> as it is an invalid HTML." !important;
+}
+
+a[href]:not([aria-label]):not([aria-labelledby]):empty::after {
+  content: "ERROR: Ensure that <a> has meaningful content or is labeled appropriately." !important;
 }
 
 ol > *:not(li)::after, ul > *:not(li)::after {

--- a/features.md
+++ b/features.md
@@ -41,5 +41,7 @@ A list of every a11y concern Checka11y.css will check for and highlight with lin
   - They are reachable by assistive technologies (no `aria-hidden`)
 - Checks there aren't any `!important` inline styles
 - Checks usage `accesskey` attribute in elements should be avoided
-
+- Checks if the following have meaningful content:
+  - `<a>[href]` only checks hyperlinks: Read about [Success Criterion 2.4.4 Link Purpose (In Context)](https://www.w3.org/TR/WCAG21/#link-purpose-in-context) and [Empty links](https://webaim.org/techniques/hypertext/link_text#empty_links)
+  - `<button>`: Read about [Success Criterion 2.4.4 Link Purpose (In Context)](https://www.w3.org/TR/WCAG21/#link-purpose-in-context)
 ---

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "Alvaro Montoro <alvaromontoro@gmail.com> (https://github.com/alvaromontoro)",
     "Manaswini Munuguri (https://github.com/Manaswini1832)",
     "Shona McKenzie (https://github.com/shonamckenzie)",
-    "Ashar Setiawan (https://github.com/azhsetiawan)"
+    "Ashar Setiawan (https://github.com/azhsetiawan)",
+    "Bogdan Lazar (https://github.com/tricinel)"
   ],
   "keywords": [
     "checka11y",

--- a/src/features/_buttons.scss
+++ b/src/features/_buttons.scss
@@ -57,3 +57,11 @@ button {
     @extend %voidError;
   }
 }
+
+/* Buttons have meaningful content */
+button:not( [aria-label] ):not( [aria-labelledby] ):empty {
+  &::after {
+    @extend %contentError;
+    @include contentMessage(error, "Ensure that <button> has meaningful content or is labeled appropriately.");
+  }
+}

--- a/src/features/_buttons.scss
+++ b/src/features/_buttons.scss
@@ -62,6 +62,6 @@ button {
 button:not( [aria-label] ):not( [aria-labelledby] ):empty {
   &::after {
     @extend %contentError;
-    @include contentMessage(error, "Ensure that <button> has meaningful content or is labeled appropriately.");
+    @include contentMessage(error, "Ensure that <button> has meaningful content or is labelled appropriately.");
   }
 }

--- a/src/features/_links.scss
+++ b/src/features/_links.scss
@@ -65,3 +65,11 @@ a {
     @extend %voidError;
   }
 }
+
+/* Anchors used as links have meaningful content */
+a[href]:not( [aria-label] ):not( [aria-labelledby] ):empty {
+  &::after {
+    @extend %contentError;
+    @include contentMessage(error, "Ensure that <a> has meaningful content or is labeled appropriately.");
+  }
+}

--- a/src/features/_links.scss
+++ b/src/features/_links.scss
@@ -70,6 +70,6 @@ a {
 a[href]:not( [aria-label] ):not( [aria-labelledby] ):empty {
   &::after {
     @extend %contentError;
-    @include contentMessage(error, "Ensure that <a> has meaningful content or is labeled appropriately.");
+    @include contentMessage(error, "Ensure that <a> has meaningful content or is labelled appropriately.");
   }
 }

--- a/test/index.html
+++ b/test/index.html
@@ -242,7 +242,7 @@
       </div>
     </section>
     <section>
-      <h2>Links should have meaningful content or be labeled appropriately for assistive technologies</h2>
+      <h2>Links should have meaningful content or be labelled appropriately for assistive technologies</h2>
       <div>
         <a href="https://github.com/jackdomleo7/Checka11y.css"></a>
         <a>Hello, I am an anchor</a>
@@ -251,7 +251,7 @@
       </div>
     </section>
     <section>
-      <h2>Buttons should have meaningful content or be labeled appropriately for assistive technologies</h2>
+      <h2>Buttons should have meaningful content or be labelled appropriately for assistive technologies</h2>
       <div>
         <button></button>
         <button>Hello, I am a button</button>

--- a/test/index.html
+++ b/test/index.html
@@ -241,5 +241,23 @@
         <button accesskey="s">Save</button>
       </div>
     </section>
+    <section>
+      <h2>Links should have meaningful content or be labeled appropriately for assistive technologies</h2>
+      <div>
+        <a href="https://github.com/jackdomleo7/Checka11y.css"></a>
+        <a>Hello, I am an anchor</a>
+        <a href aria-label="I am empty but have an aria-label"></a>
+        <a href aria-labelledby="id-to-element"></a>
+      </div>
+    </section>
+    <section>
+      <h2>Buttons should have meaningful content or be labeled appropriately for assistive technologies</h2>
+      <div>
+        <button></button>
+        <button>Hello, I am a button</button>
+        <button aria-label="I am empty but have an aria-label"></button>
+        <button aria-labelledby="id-to-element"></button>
+      </div>
+    </section>
   </body>
 </html>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

Buttons and links that are not labeled appropriately (either with aria-label or aria-labelledby) and are empty are not of much help to assistive technologies.

<!-- If this pull request is to check for a new a11y feature or modify an existing a11y feature check, please label it as `a11y feature` -->
<!-- If this pull request is to enhance anything else in the project (I.e. linting, dependencies, README, architecture, etc), please label it as `project enhancement` -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!-- Describe your changes in clear detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

We're checking for:
- all anchors that have a `href` property and are not labeled and are empty
- all buttons that are not labeled and are empty

These elements break the [Success Criterion 2.4.4 Link Purpose (In Context)](https://www.w3.org/TR/WCAG21/#link-purpose-in-context).

This fixes #34.

## Link(s)
<!-- Please provide any relevant links used in your investigation in this work. -->
<!-- Try linking to trusted sites such as w3.org, developer.mozilla.org, a11yproject.com, inclusive-components.design, etc -->

- [https://www.w3.org/TR/WCAG21/#link-purpose-in-context](https://www.w3.org/TR/WCAG21/#link-purpose-in-context)

## Screenshot(s)
<!-- Please include at least 1 screenshot if you have labelled this pull request as `a11y feature` -->
![Checka11y fix for 34](https://i.postimg.cc/DZTZmv5c/Checka11y-34.png)

## Checklist:
<!-- Put an `x` in all the boxes that apply. -->
<!-- Please do not submit the PR for review until most of the boxes are completed. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have thoroughly read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines.
- [x] I understand my pull request will be thoroughly reviewed at high detail.
- [x] I understand the work in my pull request will **only** be available in the next version release of Checka11y.css and not in the current version release.
- [x] I confirm the work in this pull request is valid according to my findings and is not something for anything personal.
- [x] I have updated the [README](../README.md) where and if applicable (still put an `x` if you have considered this but thought there was nothing to add or modify).
- [x] I have added myself to the `contributors` section in `package.json` (still put an `x` if you have considered this but decided not to add yourself).
- [x] I have checked I have **not** committed any **accidental** files.
- [x] I have tested all the main modern browsers (I.e. Chrome, Firefox, Edge, Safari - please leave this unchecked if there were any browsers listed you could not test and list them in the [help](#help) section with details why you couldn't test that browser)
- [x] All new and existing a11y checks still work correctly (compare your local `test/index.html` to the `test/index.html` in the `master` branch).

## Help
<!-- Please provide any details here that you require any further help or assistance with. -->
<!-- E.g. I could not test in Safari because I do not have access to an Apple device. -->