### PR TITLE
Check for meaningful alt on images

### DIFF
--- a/checka11y.css
+++ b/checka11y.css
@@ -2,7 +2,7 @@
 :root {
   --text-error: #721c24;
   --bg-error: #ffc6c6;
-  --border-error: #f00;
+  --border-error: red;
   --text-warning: #856404;
   --bg-warning: #ffffd8;
   --border-warning: #ff6;
@@ -39,9 +39,20 @@ button button::after, button details::after, button label::after, button:not([ar
 }
 
 img[alt="image" i], img[alt="graphic" i], img[alt="photo" i], img[alt="photograph" i], img[alt="drawing" i], img[alt="painting" i], img[alt="artwork" i], img[alt="logo" i], img[alt="bullet" i], img[alt="button" i], img[alt="arrow" i], img[alt="more" i], img[alt="spacer" i], img[alt="blank" i], img[alt="chart" i], img[alt="table" i], img[alt="diagram" i], img[alt="graph" i], img[alt="*" i], img[alt=" " i], img[alt$=".png" i], img[alt$=".gif" i], img[alt$=".jpg" i], img[alt$=",jpeg" i], img[alt$=".svg" i], img[alt$=".bmp" i], img[alt$="image" i], img[alt$="graphic" i], img[alt^="graphic of" i], img[alt^="bullet" i], img[alt^="image of" i] {
-  background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="400px" height="80px" viewBox="0 0 400 80"><rect class="box" x="4" y="4" width="392" height="72" rx="12" ry="12" fill="%23ffffd8" stroke-width="0.4rem" stroke="%23ff6" /><g fill="%23856404" font-size="1.2rem" font-weight="bold" font-family="Verdana, Geneva, Tahoma, sans-serif"><text x="15" y="35">WARNING: Alt text must describe</text><text x="15" y="60">the content of the image.</text></g></svg>') bottom center no-repeat;
   border: 0.4rem solid var(--border-warning);
+  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="400px" height="80px" viewBox="0 0 400 80"><rect class="box" x="4" y="4" width="392" height="72" rx="12" ry="12" fill="rgba(255,255,216,0.999999)" stroke-width="0.4rem" stroke="rgba(255,255,102,0.999999)" /><g fill="rgba(133,100,4,0.999999)" font-size="1.2rem" font-weight="bold" font-family="Verdana, Geneva, Tahoma, sans-serif"><text x="15" y="35">WARNING: Alt text must describe</text> <text x="15" y="60">the content of the image.</text></g></svg>');
+  background-position: bottom center;
+  background-repeat: no-repeat;
   min-width: 400px;
+  padding-bottom: 80px;
+}
+
+button embed {
+  border: 0.4rem solid var(--border-error);
+  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="350px" height="80px" viewBox="0 0 350 80"><rect class="box" x="4" y="4" width="342" height="72" rx="12" ry="12" fill="rgba(255,198,198,0.999999)" stroke-width="0.4rem" stroke="rgba(255,0,0,0.999999)" /><g fill="rgba(114,28,36,0.999999)" font-size="1.2rem" font-weight="bold" font-family="Verdana, Geneva, Tahoma, sans-serif"><text x="15" y="35">ERROR: &lt;embed&gt; can not be</text> <text x="15" y="60">a child of &lt;button&gt;.</text></g></svg>');
+  background-position: bottom center;
+  background-repeat: no-repeat;
+  min-width: 350px;
   padding-bottom: 80px;
 }
 

--- a/checka11y.css
+++ b/checka11y.css
@@ -38,6 +38,13 @@ button button::after, button details::after, button label::after, button:not([ar
   background-color: var(--bg-warning);
 }
 
+img[alt="image" i], img[alt="graphic" i], img[alt="photo" i], img[alt="photograph" i], img[alt="drawing" i], img[alt="painting" i], img[alt="artwork" i], img[alt="logo" i], img[alt="bullet" i], img[alt="button" i], img[alt="arrow" i], img[alt="more" i], img[alt="spacer" i], img[alt="blank" i], img[alt="chart" i], img[alt="table" i], img[alt="diagram" i], img[alt="graph" i], img[alt="*" i], img[alt=" " i], img[alt$=".png" i], img[alt$=".gif" i], img[alt$=".jpg" i], img[alt$=",jpeg" i], img[alt$=".svg" i], img[alt$=".bmp" i], img[alt$="image" i], img[alt$="graphic" i], img[alt^="graphic of" i], img[alt^="bullet" i], img[alt^="image of" i] {
+  background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="400px" height="80px" viewBox="0 0 400 80"><rect class="box" x="4" y="4" width="392" height="72" rx="12" ry="12" fill="%23ffffd8" stroke-width="0.4rem" stroke="%23ff6" /><g fill="%23856404" font-size="1.2rem" font-weight="bold" font-family="Verdana, Geneva, Tahoma, sans-serif"><text x="15" y="35">WARNING: Alt text must describe</text><text x="15" y="60">the content of the image.</text></g></svg>') bottom center no-repeat;
+  border: 0.4rem solid var(--border-warning);
+  min-width: 400px;
+  padding-bottom: 80px;
+}
+
 [accesskey]::after {
   content: "WARNING: accesskey attribute could interfere and conflict with screen readers and assistive technologies." !important;
 }

--- a/features.md
+++ b/features.md
@@ -44,4 +44,5 @@ A list of every a11y concern Checka11y.css will check for and highlight with lin
 - Checks if the following have meaningful content:
   - `<a>[href]` only checks hyperlinks: Read about [Success Criterion 2.4.4 Link Purpose (In Context)](https://www.w3.org/TR/WCAG21/#link-purpose-in-context) and [Empty links](https://webaim.org/techniques/hypertext/link_text#empty_links)
   - `<button>`: Read about [Success Criterion 2.4.4 Link Purpose (In Context)](https://www.w3.org/TR/WCAG21/#link-purpose-in-context)
+- Checks that the alt attributes have meaningful content
 ---

--- a/src/_base.scss
+++ b/src/_base.scss
@@ -1,3 +1,5 @@
+@import "variables.scss";
+
 /**
   * Base Styles
   * To use in SCSS with the @extend & @include command.
@@ -32,13 +34,6 @@
   background-color: var(--bg-warning);
 }
 
-%imageMeaningfulAlt {
-  background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="400px" height="80px" viewBox="0 0 400 80"><rect class="box" x="4" y="4" width="392" height="72" rx="12" ry="12" fill="%23ffffd8" stroke-width="0.4rem" stroke="%23ff6" /><g fill="%23856404" font-size="1.2rem" font-weight="bold" font-family="Verdana, Geneva, Tahoma, sans-serif"><text x="15" y="35">WARNING: Alt text must describe</text><text x="15" y="60">the content of the image.</text></g></svg>') bottom center no-repeat;
-  border: 0.4rem solid var(--border-warning);
-  min-width: 400px;
-  padding-bottom: 80px;
-}
-
 @mixin contentMessage($errorType, $message) {
   @if $errorType == error {
     content: "ERROR: #{$message}" !important;
@@ -49,4 +44,67 @@
   @else {
     @error "The errorType must be either error or warning.";
   }
+}
+
+/**
+* ---------------------------
+* Background image processing
+*/
+@function generate-text-lines($lines) {
+  $textLines: ();
+  @each $line in $lines {
+    // stylelint-disable-next-line scss/no-duplicate-dollar-variables
+    $textLines: append($textLines, '<text x="15" y="#{index($lines, $line) * 25 + 10}">#{$line}</text>');
+  }
+
+  @if length($textLines) == 0 {
+    // stylelint-disable-next-line scss/no-duplicate-dollar-variables
+    $textLines: ('<text x="15" y="35">CAUTION: Unidentified issue</text>');
+  }
+
+  @return $textLines;
+}
+
+/**
+* errorType: type of the notification (error or warning)
+* width: width of the generated image (the whole element will be set to this width)
+* lines: the rest of the parameters as a list (the lines of text to be displayed)
+*
+* ****IMPORTANT****: Avoid special characters (#, <, >) when possible, or replace
+*                    them with HTML entities (< --> &lt; etc)
+*/
+@mixin imageMessage($errorType: "warning", $width: 400, $lines...) {
+  $border-svg: $border-error;
+  $bg-svg: $bg-error;
+  $text-svg: $text-error;
+
+  $textLines: generate-text-lines($lines);
+  $height: length($textLines) * 25 + 30; // number of lines * 25 (line height) + 30 (padding top and bottom)
+
+  @if $errorType == error {
+    border: 0.4rem solid var(--border-error);
+  }
+  @else if $errorType == warning {
+    $border-svg: $border-warning; // stylelint-disable-line scss/no-duplicate-dollar-variables
+    $bg-svg: $bg-warning; // stylelint-disable-line scss/no-duplicate-dollar-variables
+    $text-svg: $text-warning; // stylelint-disable-line scss/no-duplicate-dollar-variables
+    border: 0.4rem solid var(--border-warning);
+  }
+  @else {
+    @error "The errorType must be either error or warning.";
+  }
+  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="#{$width}px" height="#{$height}px" viewBox="0 0 #{$width} #{$height}"><rect class="box" x="4" y="4" width="#{$width - 8}" height="#{$height - 8}" rx="12" ry="12" fill="#{transparentize($bg-svg, 0.000001)}" stroke-width="0.4rem" stroke="#{transparentize($border-svg, 0.000001)}" /><g fill="#{transparentize($text-svg, 0.000001)}" font-size="1.2rem" font-weight="bold" font-family="Verdana, Geneva, Tahoma, sans-serif">#{$textLines}</g></svg>');
+  background-position: bottom center;
+  background-repeat: no-repeat;
+  min-width: #{$width}px;
+  padding-bottom: #{$height}px;
+}
+
+%imageMeaningfulAlt {
+  @include imageMessage("warning", 400, "WARNING: Alt text must describe", "the content of the image.");
+}
+
+
+%embedInsideButton {
+  @include imageMessage("error", 350, "ERROR: &lt;embed&gt; can not be", "a child of &lt;button&gt;.");
 }

--- a/src/_base.scss
+++ b/src/_base.scss
@@ -32,6 +32,13 @@
   background-color: var(--bg-warning);
 }
 
+%imageMeaningfulAlt {
+  background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="400px" height="80px" viewBox="0 0 400 80"><rect class="box" x="4" y="4" width="392" height="72" rx="12" ry="12" fill="%23ffffd8" stroke-width="0.4rem" stroke="%23ff6" /><g fill="%23856404" font-size="1.2rem" font-weight="bold" font-family="Verdana, Geneva, Tahoma, sans-serif"><text x="15" y="35">WARNING: Alt text must describe</text><text x="15" y="60">the content of the image.</text></g></svg>') bottom center no-repeat;
+  border: 0.4rem solid var(--border-warning);
+  min-width: 400px;
+  padding-bottom: 80px;
+}
+
 @mixin contentMessage($errorType, $message) {
   @if $errorType == error {
     content: "ERROR: #{$message}" !important;

--- a/src/_customisation.scss
+++ b/src/_customisation.scss
@@ -1,13 +1,15 @@
+@import "variables.scss";
+
 :root {
   /* Colors */
 
-  --text-error: #721c24;
-  --bg-error: #ffc6c6;
-  --border-error: #f00;
+  --text-error: #{$text-error};
+  --bg-error: #{$bg-error};
+  --border-error: #{$border-error};
 
-  --text-warning: #856404;
-  --bg-warning: #ffffd8;
-  --border-warning: #ff6;
+  --text-warning: #{$text-warning};
+  --bg-warning: #{$bg-warning};
+  --border-warning: #{$border-warning};
 
   /* Scale */
   --space: 0.25rem;

--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -1,0 +1,7 @@
+$text-error: #721c24;
+$bg-error: #ffc6c6;
+$border-error: #f00;
+
+$text-warning: #856404;
+$bg-warning: #ffffd8;
+$border-warning: #ff6;

--- a/src/features/_buttons.scss
+++ b/src/features/_buttons.scss
@@ -20,6 +20,7 @@ button {
 
   embed {
     @extend %voidError;
+    @extend %embedInsideButton;
   }
 
   iframe {

--- a/src/features/_images.scss
+++ b/src/features/_images.scss
@@ -2,3 +2,26 @@
 img:not( [alt] ) {
   @extend %voidError;
 }
+
+/* Images should have a meaningful alt value */
+$suspiciousAltFull: "image", "graphic", "photo", "photograph", "drawing", "painting", "artwork", "logo", "bullet",
+  "button", "arrow", "more", "spacer", "blank", "chart", "table", "diagram", "graph", "*", " ";
+$suspiciousAltEnd: ".png", ".gif", ".jpg", ",jpeg", ".svg", ".bmp", "image", "graphic";
+$suspiciousAltStart: "graphic of", "bullet", "image of";
+
+@each $alt in $suspiciousAltFull {
+  img[alt="#{$alt}"i] {
+    @extend %imageMeaningfulAlt;
+  }
+}
+@each $alt in $suspiciousAltEnd {
+  img[alt$="#{$alt}"i] {
+    @extend %imageMeaningfulAlt;
+  }
+}
+@each $alt in $suspiciousAltStart {
+  img[alt^="#{$alt}"i] {
+    @extend %imageMeaningfulAlt;
+  }
+}
+

--- a/test/index.html
+++ b/test/index.html
@@ -20,6 +20,39 @@
       <img src="./assets/a11y.png" />
     </section>
     <section>
+      <h2>Images: All images should have a meaningful and descriptive alt attribute.</h2>
+      <img alt=" " src="./assets/a11y.png" />
+      <img alt="*" src="./assets/a11y.png" />
+      <img alt="iMaGe" src="./assets/a11y.png" />
+      <img alt="graphic" src="./assets/a11y.png" />
+      <img alt="photo" src="./assets/a11y.png" />
+      <img alt="photograph" src="./assets/a11y.png" />
+      <img alt="drawing" src="./assets/a11y.png" />
+      <img alt="painting" src="./assets/a11y.png" />
+      <img alt="artwork" src="./assets/a11y.png" />
+      <img alt="logo" src="./assets/a11y.png" />
+      <img alt="bullet" src="./assets/a11y.png" />
+      <img alt="button" src="./assets/a11y.png" />
+      <img alt="arrow" src="./assets/a11y.png" />
+      <img alt="more" src="./assets/a11y.png" />
+      <img alt="spacer" src="./assets/a11y.png" />
+      <img alt="blank" src="./assets/a11y.png" />
+      <img alt="chart" src="./assets/a11y.png" />
+      <img alt="table" src="./assets/a11y.png" />
+      <img alt="diagram" src="./assets/a11y.png" />
+      <img alt="graph" src="./assets/a11y.png" />
+      <img alt="myfile.png" src="./assets/a11y.png" />
+      <img alt="myfile.jpg" src="./assets/a11y.png" />
+      <img alt="myfile.gif" src="./assets/a11y.png" />
+      <img alt="myfile.svg" src="./assets/a11y.png" />
+      <img alt="myfile.bmp" src="./assets/a11y.png" />
+      <img alt="image image" src="./assets/a11y.png" />
+      <img alt="image graphic" src="./assets/a11y.png" />
+      <img alt="graphic of a graphic" src="./assets/a11y.png" />
+      <img alt="image of an image" src="./assets/a11y.png" />
+      <img alt="bullet 1" src="./assets/a11y.png" />
+    </section>
+    <section>
       <h2>iframe: iframe has title attribute</h2>
       <iframe src="https://checka11y.jackdomleo.dev" height="500" width="500"></iframe>
     </section>


### PR DESCRIPTION
- Add selectors for same cases detected by Wave
- Add generic message as background-image
- Add examples for each generic alt

<!-- Provide a general summary of your changes in the title above -->

<!-- If this pull request is to check for a new a11y feature or modify an existing a11y feature check, please label it as `a11y feature` -->
<!-- If this pull request is to enhance anything else in the project (I.e. linting, dependencies, README, architecture, etc), please label it as `project enhancement` -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!-- Describe your changes in clear detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

Images should nave a descriptive alternative text. Images in which the alternative text is "image" or "graphic" or a " " (blank space), are not providing enough information for assistive technologies. This PR adds a warning to those cases.

Resolves: #35 

## Link(s)
<!-- Please provide any relevant links used in your investigation in this work. -->
<!-- Try linking to trusted sites such as w3.org, developer.mozilla.org, a11yproject.com, inclusive-components.design, etc -->

- [WebAIM: alternative text](https://webaim.org/techniques/alttext/)

## Screenshot(s)
<!-- Please include at least 1 screenshot if you have labelled this pull request as `a11y feature` -->

Finally went for something more consistent with the rest of the error/warning messages. Based on what @cat-street suggested on [this comment](https://github.com/jackdomleo7/Checka11y.css/issues/52#issuecomment-703313123)

![Screenshot of an image with a border and a warning message below](https://i.stack.imgur.com/a3a5F.png)

## Checklist:
<!-- Put an `x` in all the boxes that apply. -->
<!-- Please do not submit the PR for review until most of the boxes are completed. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have thoroughly read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines.
- [x] I understand my pull request will be thoroughly reviewed at high detail.
- [x] I understand the work in my pull request will **only** be available in the next version release of Checka11y.css and not in the current version release.
- [x] I confirm the work in this pull request is valid according to my findings and is not something for anything personal.
- [x] I have updated the [README](../README.md) and/or [features.md](../features.md) where and if applicable (still put an `x` if you have considered this but thought there was nothing to add or modify).
- [x] I have added myself to the `contributors` section in `package.json` (still put an `x` if you have considered this but decided not to add yourself).
- [x] I have checked I have **not** committed any **accidental** files.
- [x] I have tested all the main modern browsers (I.e. Chrome, Firefox, Edge, Safari - please leave this unchecked if there were any browsers listed you could not test and list them in the [help](#help) section with details why you couldn't test that browser)
- [x] All new and existing a11y checks still work correctly (compare your local `test/index.html` to the `test/index.html` in the `master` branch).

## Help
<!-- Please provide any details here that you require any further help or assistance with. -->
<!-- E.g. I could not test in Safari because I do not have access to an Apple device. -->

Tested on Chrome, Safari, and Firefox on Mac. Needs to be tested on Windows and IE/Edge.