### PR TITLE
Continuous Integration & Move inline shared commands to commands file

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,0 +1,20 @@
+name: Chrome headless
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  cypress-run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: cypress-io/github-action@v2
+        with:
+          browser: chrome
+          headless: true
+          spec: cypress/integration/a11y_spec.js

--- a/cypress/integration/a11y_spec.js
+++ b/cypress/integration/a11y_spec.js
@@ -4,40 +4,6 @@ describe('CheckA11y.css Tests', () => {
   const WARNING_BOXSHADOW = 'rgb(255, 255, 102) 0px 0px 0px 4px';
   const ERROR_BORDER = '6.4px solid rgb(255, 0, 0)';
 
-  /**
-  * Code adapted from Victor Navarro: https://stackoverflow.com/a/57249958/3695983
-  */
-  const unquote = str => str.replace(/(^")|("$)/g, '');
-
-  /**
-   * Add command "before" to Cypress.
-   * This command will take a CSS property as a string parameter, and return the value
-   * of the property in the ::before of the selected element.
-   * Example of use: cy.get("button").before("content") will return the value of the
-   * content property of the button element.
-   */
-  Cypress.Commands.add(
-    'before',
-    { prevSubject: 'element' },
-    (el, property) => {
-      const win = el[0].ownerDocument.defaultView;
-      const before = win.getComputedStyle(el[0], 'before');
-      return unquote(before.getPropertyValue(property));
-    },
-  );
-  /**
-   * Add command "after" to Cypress.
-   * Same as above, but for the ::after pseudo-element.
-   */
-  Cypress.Commands.add(
-    'after',
-    { prevSubject: 'element' },
-    (el, property) => {
-      const win = el[0].ownerDocument.defaultView;
-      const before = win.getComputedStyle(el[0], 'after');
-      return unquote(before.getPropertyValue(property));
-    },
-  );
   /**********/
 
   before(() => {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -23,3 +23,39 @@
 //
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
+
+/**
+ * Code adapted from Victor Navarro: https://stackoverflow.com/a/57249958/3695983
+ */
+const unquote = str => str.replace(/(^")|("$)/g, '');
+
+/**
+ * Add command "before" to Cypress.
+ * This command will take a CSS property as a string parameter, and return the value
+ * of the property in the ::before of the selected element.
+ * Example of use: cy.get("button").before("content") will return the value of the
+ * content property of the button element.
+ */
+Cypress.Commands.add(
+  'before',
+  { prevSubject: 'element' },
+  (el, property) => {
+    const win = el[0].ownerDocument.defaultView;
+    const before = win.getComputedStyle(el[0], 'before');
+    return unquote(before.getPropertyValue(property));
+  },
+);
+
+/**
+ * Add command "after" to Cypress.
+ * Same as above, but for the ::after pseudo-element.
+ */
+Cypress.Commands.add(
+  'after',
+  { prevSubject: 'element' },
+  (el, property) => {
+    const win = el[0].ownerDocument.defaultView;
+    const before = win.getComputedStyle(el[0], 'after');
+    return unquote(before.getPropertyValue(property));
+  },
+);


### PR DESCRIPTION
CI cypress for GitHub actions 

Addresses #72  (CI tests, not linting)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Chore improves repo, but is not bug or feature

## Description

* Move commands out of the only test case and into commands
* Use Cypress GitHub action to test

## Link(s)

* https://github.com/cypress-io/github-action
* [Passing CI](https://github.com/Lewiscowles1986/Checka11y.css/pull/2/checks?check_run_id=1310314083)

## Screenshot(s)

N/A

## Checklist:

- [X] I have thoroughly read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines.
- [X] I understand my pull request will be thoroughly reviewed at high detail.
- [X] I understand the work in my pull request will **only** be available in the next version release of Checka11y.css and not in the current version release.
- [X] I confirm the work in this pull request is valid according to my findings and is not something for anything personal.
- [X] I have updated the [README](../README.md) and/or [features.md](../features.md) where and if applicable (still put an `x` if you have considered this but thought there was nothing to add or modify).
- [X] I have added myself to the `contributors` section in `package.json` (still put an `x` if you have considered this but decided not to add yourself).
- [X] I have checked I have **not** committed any **accidental** files.
- [X] I have tested all the main modern browsers (I.e. Chrome, Firefox, Edge, Safari - please leave this unchecked if there were any browsers listed you could not test and list them in the [help](#help) section with details why you couldn't test that browser)
- [X] I have run the automated tests and added new ones to cover new code.
- [X] All new and existing a11y checks still work correctly (compare your local `test/index.html` to the `test/index.html` in the `master` branch).

## Help

Clicking the actions tab, this should have run and passed when it's ready.

This also will not run on this repo from this PR. I don't actually know why that is, but I'm assuming once it merges, this will be run. It might be about preventing me as a non-contributor from running CI which might do things. It has run on a PR I raised against the forked repo. [Passing CI](https://github.com/Lewiscowles1986/Checka11y.css/pull/2/checks?check_run_id=1310314083)

## Additional work needed to guard a branch

1. Click on repository settings
    ![image](https://user-images.githubusercontent.com/2605791/97207336-d0859e00-17b1-11eb-9b35-b8d922650712.png)
2. Click on Branches
    ![image](https://user-images.githubusercontent.com/2605791/97206692-f8c0cd00-17b0-11eb-92d9-5fd4302a981d.png)
3. Click Add rule
    ![image](https://user-images.githubusercontent.com/2605791/97206773-18f08c00-17b1-11eb-9916-75931b1e0bb5.png)
4. Specify a branch pattern, and select shown options
    ![image](https://user-images.githubusercontent.com/2605791/97207071-771d6f00-17b1-11eb-90da-29c000c8b9a3.png)
5. Click "Create" (you may be asked to authenticate)
    ![image](https://user-images.githubusercontent.com/2605791/97207159-96b49780-17b1-11eb-8d6c-042ce8d35f06.png)

This will then ensure nobody can merge before CI passes, unless they are an admin (and it should be understood they DO NOT)