### PR TITLE
Broken copy warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ A list of common a11y concerns Checka11y.css will check for and highlight :
 - Check for media that is set to `autoplay`
 - Check `<li>` is the **only** direct child of `<ol>` and `<ul>`
 - Check for programmable-only `tabindex` attributes on invalid HTML elements
+- Check for broken copy with `role="text"` 
 
 See a full list of features [here](./features.md).
 

--- a/src/features/_inline.scss
+++ b/src/features/_inline.scss
@@ -7,7 +7,7 @@
   &:not([role="text"]){
     > em,span{
       &:after{
-        @include contentMessage(warning, "Text broken by <span> or <em> elements must contain a [role='text'] tag");
+        @include contentMessage(warning, "Text broken by <span> or <em> elements might need a [role='text'] tag");
       }
     }
   }

--- a/src/features/_inline.scss
+++ b/src/features/_inline.scss
@@ -2,3 +2,13 @@
 [style *= "!important"]::after {
   @include contentMessage(warning, "!important inline styles should be avoided.");
 }
+
+* {
+  &:not([role="text"]){
+    > em,span{
+      &:after{
+        @include contentMessage(warning, "Text broken by <span> or <em> elements must contain a [role='text'] tag");
+      }
+    }
+  }
+}

--- a/src/features/_inline.scss
+++ b/src/features/_inline.scss
@@ -7,7 +7,7 @@
   &:not([role="text"]){
     > em,span{
       &:after{
-        @include contentMessage(warning, "Text broken by <span> or <em> elements might need a [role='text'] tag");
+        @include contentMessage(warning, "Text broken by <span> or <em> elements might need a [role='text'] tag.");
       }
     }
   }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

Text that is broken into `<span>` or `<em>` tags can be difficult to read by screen readers. This can be avoided by using a `[role="text"]` tag.

<!-- If this pull request is to check for a new a11y feature or modify an existing a11y feature check, please label it as `a11y feature` -->
<!-- If this pull request is to enhance anything else in the project (I.e. linting, dependencies, README, architecture, etc), please label it as `project enhancement` -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!-- Describe your changes in clear detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

It is quite common when adding text to break it down into `<span>`s or `<em>`s to apply different styles to different chunks of text. However, screen readers also break down the text into chunks making it difficult for screen reader users to read for features that are irrelevant to the user (styling).

This change adds a warning message next to the `span` or `em` that broken copy needs a `role='text` tag.

The reason this is a warning is because the text might not always be intrusive.

## Link(s)
<!-- Please provide any relevant links used in your investigation in this work. -->
<!-- Try linking to trusted sites such as w3.org, developer.mozilla.org, a11yproject.com, inclusive-components.design, etc -->

[Broken Copy - A11y 101](https://a11y-101.com/development/broken-copy)

## Screenshot(s)
<!-- Please include at least 1 screenshot if you have labelled this pull request as `a11y feature` -->

![image](https://user-images.githubusercontent.com/478770/105024242-c4714b80-5a43-11eb-8814-cdb0619a67aa.png)

## Checklist:
<!-- Put an `x` in all the boxes that apply. -->
<!-- Please do not submit the PR for review until most of the boxes are completed. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have thoroughly read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines.
- [x] I understand my pull request will be thoroughly reviewed at high detail.
- [x] I understand the work in my pull request will **only** be available in the next version release of Checka11y.css and not in the current version release.
- [x] I confirm the work in this pull request is valid according to my findings and is not something for anything personal.
- [x] I have updated the [README](../README.md) and/or [features.md](../features.md) where and if applicable (still put an `x` if you have considered this but thought there was nothing to add or modify).
- [x] I have added myself to the `contributors` section in `package.json` (still put an `x` if you have considered this but decided not to add yourself).
- [x] I have checked I have **not** committed any **accidental** files.
- [ ] I have tested all the main modern browsers (I.e. Chrome, Firefox, Edge, Safari - please leave this unchecked if there were any browsers listed you could not test and list them in the [help](#help) section with details why you couldn't test that browser)
- [ ] I have run the automated tests and added new ones to cover new code.
- [ ] All new and existing a11y checks still work correctly (compare your local `test/index.html` to the `test/index.html` in the `master` branch).

## Help
<!-- Please provide any details here that you require any further help or assistance with. -->
<!-- E.g. I could not test in Safari because I do not have access to an Apple device. -->
