### PR TITLE
Add warning for section not containing heading element (W0012)

### DIFF
--- a/checka11y-warnings.css
+++ b/checka11y-warnings.css
@@ -168,6 +168,28 @@ a[href="#"]::after, a[role=button]::after, a[href^="javascript:"]::after {
   background-color: var(--checka11y-bg-warning);
 }
 
+section:empty::before, section > :not(h1, h2, h3, h4, h5, h6, img):last-child::before {
+  display: block;
+  font-size: 1rem;
+  font-family: verdana, geneva, tahoma, sans-serif;
+  font-weight: 700;
+  font-style: initial;
+  padding: var(--checka11y-space-4) var(--checka11y-space-6);
+  border-radius: 0.75rem;
+  letter-spacing: initial;
+  text-decoration: none;
+  text-transform: initial;
+  text-shadow: none;
+  content: "WARNING (W0012): A <section> should contain a heading element." !important;
+  color: var(--checka11y-text-warning);
+  border: 0.4rem solid var(--checka11y-border-warning);
+  background-color: var(--checka11y-bg-warning);
+}
+
+section > :is(h1, h2, h3, h4, h5, h6) ~ :not(:is(h1, h2, h3, h4, h5, h6, img)):last-child::before {
+  content: none !important;
+}
+
 [title]::after {
   display: block;
   font-size: 1rem;

--- a/checka11y.css
+++ b/checka11y.css
@@ -792,6 +792,28 @@ a[href="#"]::after, a[role=button]::after, a[href^="javascript:"]::after {
   background-color: var(--checka11y-bg-warning);
 }
 
+section:empty::before, section > :not(h1, h2, h3, h4, h5, h6, img):last-child::before {
+  display: block;
+  font-size: 1rem;
+  font-family: verdana, geneva, tahoma, sans-serif;
+  font-weight: 700;
+  font-style: initial;
+  padding: var(--checka11y-space-4) var(--checka11y-space-6);
+  border-radius: 0.75rem;
+  letter-spacing: initial;
+  text-decoration: none;
+  text-transform: initial;
+  text-shadow: none;
+  content: "WARNING (W0012): A <section> should contain a heading element." !important;
+  color: var(--checka11y-text-warning);
+  border: 0.4rem solid var(--checka11y-border-warning);
+  background-color: var(--checka11y-bg-warning);
+}
+
+section > :is(h1, h2, h3, h4, h5, h6) ~ :not(:is(h1, h2, h3, h4, h5, h6, img)):last-child::before {
+  content: none !important;
+}
+
 [title]::after {
   display: block;
   font-size: 1rem;

--- a/codes.md
+++ b/codes.md
@@ -124,3 +124,6 @@ A list of every Checka11y.css error & warning code with details on what the issu
 
 - ### W0011
   The highlighted element `<a>` has been detected to have `href="#"`, `role="button"` , `href="javascript:doSomething(0)"`. Those anchor elements are often used to trigger a click event on the page. This can be disorientating to a user, especially those with visual impairments and those with cognitive disabilities. Links should redirect to a resource/page. [Read more about this here](https://www.htmhell.dev/8-anchor-tag-used-as-button).
+
+- ### W0012
+  The `<section>` element represents a generic standalone section of a document, which doesn't have a more specific semantic element to represent it. This means `<section>` element should be identified, typically by including a heading (`<h1>`-`<h6>` element) as a child of the `<section>` element. [Read more about this here](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/section)

--- a/cypress/integration/section_spec.js
+++ b/cypress/integration/section_spec.js
@@ -1,0 +1,43 @@
+describe('<section>', () => {
+  const sectionLastChildHTML = [];
+  before(() => {
+    cy.visit('/test/index.html');
+
+    // Get all last child element from a section with heading element.
+    cy.get('section > :is( h1, h2, h3, h4, h5, h6 ) ~ :not( :is( h1, h2, h3, h4, h5, h6, img ) ):last-child')
+      .each(element => {
+        cy.get(element)
+        .invoke('prop', 'outerHTML').then(html => {
+          sectionLastChildHTML.push(html);
+        })
+    });
+  });
+
+  it('should show warning on last child if section does not have heading element', () => {
+    cy.get('section > :not( h1, h2, h3, h4, h5, h6, img ):last-child')
+      .each((element) => {
+        cy.get(element)
+          .invoke('prop', 'outerHTML').then(html => {
+            if(!sectionLastChildHTML.includes(html)) {
+              cy.get(element)
+                .before('content')
+                .should('eq', 'WARNING (W0012): A <section> should contain a heading element.');
+            }
+        })
+    });
+  });
+
+  it('should show warning on if section is empty', () => {
+    cy.get('section:empty')
+      .each((element) => {
+        cy.get(element)
+          .invoke('prop', 'outerHTML').then(html => {
+            if(!sectionLastChildHTML.includes(html)) {
+              cy.get(element)
+                .before('content')
+                .should('eq', `WARNING (W0012): A <section> should contain a heading element.`);
+            }
+        })
+    });
+  });
+});

--- a/features.md
+++ b/features.md
@@ -34,3 +34,4 @@ A list of every a11y concern Checka11y.css will check for and highlight with lin
 - [W0009](./codes.md#W0009): Checks for focusable elements inside `aria-hidden="true"` elements.
 - [W0010](./codes.md#W0010): Checks for heading elements containing `role="text"` attribute.
 - [W0011](./codes.md#W0011): Checks for anchor tags that are used as buttons.
+- [W0012](./codes.md#W0012): Checks for heading element inside `<section>` element.

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "Shona McKenzie (https://github.com/shonamckenzie)",
     "Ashar Setiawan (https://github.com/azhsetiawan)",
     "Bogdan Lazar (https://github.com/tricinel)",
-    "Martin Sidorov (https://github.com/Matrix278)"
+    "Martin Sidorov (https://github.com/Matrix278)",
+    "Shaddam Amru Hasibuan <shaddam.a.h@gmail.com> (https:/github.com/shamahdotdev)"
   ],
   "keywords": [
     "checka11y",

--- a/src/warnings/checka11y-warnings.scss
+++ b/src/warnings/checka11y-warnings.scss
@@ -12,6 +12,7 @@
 @import "./features/images";
 @import "./features/inline";
 @import "./features/links";
+@import "./features/section";
 @import "./features/title";
 @import "./features/underline";
 @import "./features/headings";

--- a/src/warnings/features/_section.scss
+++ b/src/warnings/features/_section.scss
@@ -1,0 +1,12 @@
+/* W0012: A <section> should contain a heading element */
+
+section {
+  &:empty::before,
+  > :not( h1, h2, h3, h4, h5, h6, img ):last-child::before {
+    @include contentMessage(warning, "W0012", "A <section> should contain a heading element.");
+  }
+
+  > :is( h1, h2, h3, h4, h5, h6 ) ~ :not( :is( h1, h2, h3, h4, h5, h6, img ) ):last-child::before {
+    content: none !important;
+  }
+}

--- a/test/index.html
+++ b/test/index.html
@@ -380,5 +380,15 @@
       <a href="javascript:void(0)" role="button">Do another thing</a>
       <a href="javascript:doSomething(0)">Do another thing</a>
     </section>
+    <section>
+      <h2>A <code>&lt;section&gt;</code> should contain a heading element</h2>
+      <section>
+        <h2>This is a heading element.</h1>
+      </section>
+      <section><!-- This is an empty section --></section>
+      <section>
+        <p>this is not a heading element, just a cool paragraph.</p>
+      </section>
+    </section>
   </body>
 </html>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!-- If this pull request is to check for a new a11y feature or modify an existing a11y feature check, please label it as `a11y feature` -->
<!-- If this pull request is to enhance anything else in the project (I.e. linting, dependencies, README, architecture, etc), please label it as `project enhancement` -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
This feature adds a warning to a `<section>` not containing heading element which it should be contained because a `<section>` doesn't has other specific semantic element to represent it. Resolves: #89 
<!-- Describe your changes in clear detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

## Link(s)
- https://developer.mozilla.org/en-US/docs/Web/HTML/Element/section
<!-- Please provide any relevant links used in your investigation in this work. -->
<!-- Try linking to trusted sites such as w3.org, developer.mozilla.org, a11yproject.com, inclusive-components.design, etc -->

## Screenshot(s)
![image](https://user-images.githubusercontent.com/53106916/136202615-17d18b84-eec0-4181-8a86-e94112c9556e.png)
<!-- Please include at least 1 screenshot if you have labelled this pull request as `a11y feature` -->

## Checklist:
<!-- Put an `x` in all the boxes that apply. -->
<!-- Please do not submit the PR for review until most of the boxes are completed. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have thoroughly read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines.
- [x] I understand my pull request will be thoroughly reviewed at high detail.
- [x] I understand the work in my pull request will **only** be available in the next version release of Checka11y.css and not in the current version release.
- [x] I confirm the work in this pull request is valid according to my findings and is not something for anything personal.
- [x] I have updated the [README](../README.md) and/or [features.md](../features.md) where and if applicable (still put an `x` if you have considered this but thought there was nothing to add or modify).
- [x] I have added myself to the `contributors` section in `package.json` (still put an `x` if you have considered this but decided not to add yourself).
- [x] I have checked I have **not** committed any **accidental** files.
- [ ] I have tested all the main modern browsers (I.e. Chrome, Firefox, Edge, Safari - please leave this unchecked if there were any browsers listed you could not test and list them in the [help](#help) section with details why you couldn't test that browser)
- [x] I have run the automated tests and added new ones to cover new code.
- [x] All new and existing a11y checks still work correctly (compare your local `test/index.html` to the `test/index.html` in the `master` branch).

## Help
I could not test in Safari because I do not have access to an Apple device.
<!-- Please provide any details here that you require any further help or assistance with. -->
<!-- E.g. I could not test in Safari because I do not have access to an Apple device. -->
